### PR TITLE
Prevent to overwrite on error handle

### DIFF
--- a/pkg/controllers/backends/mpi/mpi_backend_test.go
+++ b/pkg/controllers/backends/mpi/mpi_backend_test.go
@@ -330,6 +330,8 @@ func TestNewMaster(t *testing.T) {
 		if errActual != nil {
 			t.Errorf("Couldn't pretty format %v, error: %v", actualJob, errActual)
 			actual = fmt.Sprintf("%+v", actualJob)
+		} else {
+			actual = string(actualJSON)
 		}
 
 		expectedJSON, errExpected := json.MarshalIndent(c.expected, "", "  ")
@@ -337,10 +339,9 @@ func TestNewMaster(t *testing.T) {
 		if errExpected != nil {
 			t.Errorf("Couldn't pretty format %v, error: %v", c.expected, errExpected)
 			expected = fmt.Sprintf("%v", c.expected)
+		} else {
+			expected = string(expectedJSON)
 		}
-
-		actual = string(actualJSON)
-		expected = string(expectedJSON)
 
 		if !reflect.DeepEqual(actual, expected) {
 			t.Errorf("TestCase: %v\nWant:%+v\nGot:%+v", c.name, expected, actual)
@@ -507,6 +508,8 @@ func TestNewWorkerSet(t *testing.T) {
 		if errActual != nil {
 			t.Errorf("Couldn't pretty format %v, error: %v", actualSS, errActual)
 			actual = fmt.Sprintf("%+v", actualSS)
+		} else {
+			actual = string(actualJSON)
 		}
 
 		expectedJSON, errExpected := json.MarshalIndent(c.expected, "", "  ")
@@ -514,10 +517,9 @@ func TestNewWorkerSet(t *testing.T) {
 		if errExpected != nil {
 			t.Errorf("Couldn't pretty format %v, error: %v", c.expected, errExpected)
 			expected = fmt.Sprintf("%v", c.expected)
+		} else {
+			expected = string(expectedJSON)
 		}
-
-		actual = string(actualJSON)
-		expected = string(expectedJSON)
 
 		if !reflect.DeepEqual(actual, expected) {
 			t.Errorf("TestCase: %v\nWant:%+v\nGot:%+v", c.name, expected, actual)

--- a/pkg/controllers/backends/none/none_backend_test.go
+++ b/pkg/controllers/backends/none/none_backend_test.go
@@ -147,6 +147,8 @@ func TestNewMaster(t *testing.T) {
 		if errActual != nil {
 			t.Errorf("Couldn't pretty format %v, error: %v", actualJob, errActual)
 			actual = fmt.Sprintf("%+v", actualJob)
+		} else {
+			actual = string(actualJSON)
 		}
 
 		expectedJSON, errExpected := json.MarshalIndent(c.expected, "", "  ")
@@ -154,10 +156,9 @@ func TestNewMaster(t *testing.T) {
 		if errExpected != nil {
 			t.Errorf("Couldn't pretty format %v, error: %v", c.expected, errExpected)
 			expected = fmt.Sprintf("%v", c.expected)
+		} else {
+			expected = string(expectedJSON)
 		}
-
-		actual = string(actualJSON)
-		expected = string(expectedJSON)
 
 		if !reflect.DeepEqual(actual, expected) {
 			t.Errorf("TestCase: %v\nWant:%+v\nGot:%+v", c.name, expected, actual)


### PR DESCRIPTION
This PR fixes unit test, variables are overwritten on error handling.

/cc @everpeace 