### PR TITLE
mpiConfig.slots must not be nil in any case.

### DIFF
--- a/pkg/apis/chainer/v1alpha1/defaults.go
+++ b/pkg/apis/chainer/v1alpha1/defaults.go
@@ -54,9 +54,10 @@ func setWorkerSetMPISlots(spec *WorkerSetSpec, name string) {
 				}
 				spec.MPIConfig = defaultMPIConfig(slots)
 				glog.V(4).Infof("setting spec.WorkerSets[%+v].MPIConfig.Slots to %+v", name, *spec.MPIConfig.Slots)
-				break
+				return
 			}
 		}
+		spec.MPIConfig = defaultMPIConfig(Int32(DefaultSlots))
 	}
 }
 
@@ -84,9 +85,10 @@ func setMasterSpecMPISlots(spec *MasterSpec) {
 				}
 				spec.MPIConfig = defaultMPIConfig(slots)
 				glog.V(4).Infof("setting spec.Master.MPIConfig.Slots to %+v", *spec.MPIConfig.Slots)
-				break
+				return
 			}
 		}
+		spec.MPIConfig = defaultMPIConfig(Int32(DefaultSlots))
 	}
 }
 

--- a/pkg/apis/chainer/v1alpha1/defaults_test.go
+++ b/pkg/apis/chainer/v1alpha1/defaults_test.go
@@ -230,7 +230,7 @@ func TestSetDefaults_ChainerJob(t *testing.T) {
 			},
 		},
 		{
-			name: "multiple containers case doensn't set defaults Slots/ContainerName",
+			name: "multiple containers case doensn't set default ContainerName but set default Slots",
 			in: &ChainerJob{
 				Spec: ChainerJobSpec{
 					Backend: BackendTypeMPI,
@@ -270,6 +270,9 @@ func TestSetDefaults_ChainerJob(t *testing.T) {
 				Spec: ChainerJobSpec{
 					Backend: BackendTypeMPI,
 					Master: MasterSpec{
+						MPIConfig: &MPIConfig{
+							Slots: Int32(DefaultSlots),
+						},
 						Template: corev1.PodTemplateSpec{
 							Spec: corev1.PodSpec{
 								RestartPolicy: DefaultRestartPolicy,
@@ -286,6 +289,9 @@ func TestSetDefaults_ChainerJob(t *testing.T) {
 					},
 					WorkerSets: map[string]*WorkerSetSpec{
 						"ws": &WorkerSetSpec{
+							MPIConfig: &MPIConfig{
+								Slots: Int32(DefaultSlots),
+							},
 							Replicas: Int32(1),
 							Template: corev1.PodTemplateSpec{
 								Spec: corev1.PodSpec{


### PR DESCRIPTION
fixes #17 

/cc @disktnk 

- [x] update [`everpeace/chainer-operator:latest`](https://hub.docker.com/r/everpeace/chainer-operator/) just before merge