### PR TITLE
mpi backend: master should be the last in `hostfile`

### DIFF
--- a/pkg/controllers/backends/mpi/assets.go
+++ b/pkg/controllers/backends/mpi/assets.go
@@ -74,8 +74,6 @@ tried=0
 until [ "$(wc -l < ${TARGET}_new)" -eq $cluster_size ]; do
 	rm -f ${TARGET}_new
 
-	echo "${MASTER_POD_NAME} ${MASTER_SLOTS}" > ${TARGET}_new
-
 	cat ${STATEFUL_SETS_AND_SLOTS_FILE} | while read ss_s; do
 		ss=$(echo "${ss_s}" | cut -d' ' -f 1)
 		slots=$(echo "${ss_s}" | cut -d' ' -f 2)
@@ -88,6 +86,8 @@ until [ "$(wc -l < ${TARGET}_new)" -eq $cluster_size ]; do
 			fi
 		done
 	done
+	
+	echo "${MASTER_POD_NAME} ${MASTER_SLOTS}" >> ${TARGET}_new
 
 	tried=$(expr $tried + 1)
 	if [ $tried -ge $MAX_TRY ]; then


### PR DESCRIPTION
It is because normal typical usecase uses only workers in distributed learning.

we keep master in `hostfile` just for the rare scenario which user uses all the pods (master and workers) for distributed learning.

### before
Under this `hostfile`, master pod __always__ attend to `mpiexec`.  But most users want to make only workers attend to it.  There is no easy way for users to exclude master in `mpiexec`.

```
(master) # cat /kubeflow/chainer-operator/generated/hostfile
example-job-mn-master-hzp66 slots=1
example-job-mn-workerset-ws0-0 slots=1
example-job-mn-workerset-ws1-0 slots=1
```

### after
This is easier for users.  user can do in both cases by adjusting `mpiexec` parameters.  With `-n 2`, only workers will attend to distributed learning.  With `-n 3`, all the pods(master and workers) will attend to it.

```
(master) # cat /kubeflow/chainer-operator/generated/hostfile
example-job-mn-workerset-ws0-0 slots=1
example-job-mn-workerset-ws1-0 slots=1
example-job-mn-master-hzp66 slots=1
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/chainer-operator/20)
<!-- Reviewable:end -->
