### PR TITLE
fix component name in postsubmit

### DIFF
--- a/prow_config.yaml
+++ b/prow_config.yaml
@@ -10,7 +10,7 @@ workflows:
     params:
       registry: "gcr.io/kubeflow-ci"
   - app_dir: kubeflow/chainer-operator/test/workflows
-    component: rl
+    component: e2e
   # this super-short names are required so that identity lengths will be shorter than 64
     name: chr
     job_types:


### PR DESCRIPTION
post submit introdueced in #26 failed...

ref: https://k8s-gubernator.appspot.com/build/kubernetes-jenkins/logs/kubeflow_chainer-operator/kubeflow-chainer-operator-postsubmit/4/

/assign @richardsliu 
/assign @everpeace

PTAL and give lgtm and approve again?? Thanks in advance 🙇

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/chainer-operator/27)
<!-- Reviewable:end -->
